### PR TITLE
Add basic data models and tests

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,5 @@
+from .document import Document
+from .annotation import Annotation
+from .entity import Entity
+
+__all__ = ["Document", "Annotation", "Entity"]

--- a/backend/models/annotation.py
+++ b/backend/models/annotation.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from .entity import Entity
+
+@dataclass
+class Annotation:
+    """Span-based annotation tied to a document and entity."""
+    id: str
+    document_id: str
+    start_offset: int
+    end_offset: int
+    entity: Entity
+
+    def __post_init__(self) -> None:
+        if self.start_offset < 0 or self.end_offset < 0:
+            raise ValueError("Offsets must be non-negative")
+        if self.start_offset >= self.end_offset:
+            raise ValueError("start_offset must be less than end_offset")

--- a/backend/models/document.py
+++ b/backend/models/document.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import List
+from .annotation import Annotation
+
+@dataclass
+class Document:
+    """Text document that may contain annotations."""
+    id: str
+    text: str
+    annotations: List[Annotation] = field(default_factory=list)
+
+    def add_annotation(self, annotation: Annotation) -> None:
+        if annotation.document_id != self.id:
+            raise ValueError("Annotation document_id does not match Document id")
+        self.annotations.append(annotation)

--- a/backend/models/entity.py
+++ b/backend/models/entity.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+@dataclass
+class Entity:
+    """Represents a labeled concept."""
+    id: str
+    label: str

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from backend.models import Document, Annotation, Entity
+
+
+def test_annotation_offsets_validation():
+    entity = Entity(id="e1", label="PERSON")
+    with pytest.raises(ValueError):
+        Annotation(id="a1", document_id="d1", start_offset=5, end_offset=5, entity=entity)
+    with pytest.raises(ValueError):
+        Annotation(id="a1", document_id="d1", start_offset=-1, end_offset=5, entity=entity)
+
+
+def test_document_annotation_relationship():
+    doc = Document(id="d1", text="Hello world")
+    entity = Entity(id="e1", label="GREETING")
+    ann = Annotation(id="a1", document_id="d1", start_offset=0, end_offset=5, entity=entity)
+    doc.add_annotation(ann)
+    assert doc.annotations[0] is ann
+    assert ann.entity.label == "GREETING"
+    assert ann.start_offset == 0
+    assert ann.end_offset == 5
+
+    ann2 = Annotation(id="a2", document_id="d2", start_offset=6, end_offset=11, entity=entity)
+    with pytest.raises(ValueError):
+        doc.add_annotation(ann2)


### PR DESCRIPTION
## Summary
- implement Entity, Annotation, and Document dataclasses with relationships and validation
- add unit tests validating offsets and document link checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b996119d4483319fe370af69c977d4