### PR TITLE
Add Docker Compose setup and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
 # novoBrat
+
+## Structure du projet
+- `backend/` : API Flask minimale pour l'import, l'annotation et l'export de textes.
+- `frontend/` : interface web statique pour annoter les documents.
+- `tests/` : tests unitaires des modèles et de la base de données.
+
+## Prérequis
+- Python 3.11+
+- `pip` pour installer les dépendances du backend
+- (Optionnel) Docker et Docker Compose pour un démarrage rapide
+
+## Installation
+### Avec Docker
+1. Construire et lancer les services :
+   ```bash
+   docker compose up
+   ```
+2. Le backend est disponible sur `http://localhost:5000` et le frontend sur `http://localhost:8080`.
+
+### Installation manuelle
+1. Installer les dépendances du backend :
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Démarrer le backend :
+   ```bash
+   python backend/app.py
+   ```
+3. Servir le frontend statique (par exemple via Python) :
+   ```bash
+   python -m http.server 8080 --directory frontend
+   ```
+
+## Exemple d'utilisation
+1. **Importer un texte** :
+   ```bash
+   curl -X POST http://localhost:5000/documents \
+        -H "Content-Type: application/json" \
+        -d '{"text": "Bonjour monde"}'
+   ```
+2. **Annoter** :
+   - Ouvrir `http://localhost:8080` dans un navigateur.
+   - Sélectionner une portion du texte et choisir un label.
+3. **Exporter les annotations** :
+   ```bash
+   curl http://localhost:5000/annotations
+   ```
+   Les annotations sont retournées au format JSON.
+
+## Tests
+Lancer l'ensemble des tests avec :
+```bash
+pytest
+```
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "5000:5000"
+  frontend:
+    image: nginx:alpine
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend
+


### PR DESCRIPTION
## Summary
- document project structure, setup instructions, and usage flow in README
- add Docker Compose and backend Dockerfile for quick start

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b999954cc883319554b35152ba5358